### PR TITLE
Correct comment in example pattern

### DIFF
--- a/config-example.js
+++ b/config-example.js
@@ -8,7 +8,7 @@ var config = {
       "join": "https://mypath.webex.com/join/",
       "DEFAULT": "https://mypath.webex.com/"
     },
-    pattern: /^\:webex\s+(personal\s+(\w+))\s*$/, //Default is: /webex personal username
+    pattern: /^\:webex\s+(personal\s+(\w+))\s*$/, //Default is: :webex personal <username>
     verbose: true,
     emoji: ":webex:"//NOTE: you'll need to add this emoji
 

--- a/config-example.js
+++ b/config-example.js
@@ -8,7 +8,7 @@ var config = {
       "join": "https://mypath.webex.com/join/",
       "DEFAULT": "https://mypath.webex.com/"
     },
-    pattern: /^\:webex\s+(personal\s+(\w+))\s*$/, //Default is: :webex personal <username>
+    pattern: /^\:webex\s+(personal\s+([\w\.]+))\s*$/, //Default is: :webex personal <username>
     verbose: true,
     emoji: ":webex:"//NOTE: you'll need to add this emoji
 


### PR DESCRIPTION
The example config file contains a pattern. The comment on this line implies that the correct command to use us /webex. In fact the pattern looks for :webex

Additionally the pattern didn't work for us because we use the first half of our email addresses as our Webex usernames. This change adds full stops to the search pattern so that if they are included in the username it will still be recognised as a username.